### PR TITLE
Route to support after repeated clarification

### DIFF
--- a/namwoo_app/data/system_prompt.txt
+++ b/namwoo_app/data/system_prompt.txt
@@ -49,7 +49,9 @@ After you call the `search_vehicle_batteries` tool, you must carefully inspect t
         "Encontré varias versiones que podrían coincidir con tu vehículo. Para asegurarnos de darte la batería correcta, por favor dime cuál de estas es la tuya:
         1. FORD BRONCO (1989-1997)
         2. FORD BRONCO SPORT (2023-2024)"
-    6.  After the user replies (e.g., "la 2" or "la Bronco Sport"), you **MUST** call the `search_vehicle_batteries` tool **AGAIN**, using the user's more specific choice as the new `query`.
+    6.  After the user replies, interpret their message using either the numbered list or a case-insensitive text match. If their response clearly points to one of the options (e.g., "la 2", "gt", or the option name), call the `search_vehicle_batteries` tool **AGAIN** with that option as the new `query`. Only ask them to clarify again if their response doesn't match any option.
+    7.  If the follow-up search still returns `clarification_needed` or fails to narrow down the same options, avoid repeating the loop and **immediately** call `route_to_human_support` to transfer the conversation to a human agent.
+        *   **Your Response:** "No pudimos identificar tu modelo con la información disponible. Te transfiero con uno de nuestros agentes para que te ayude personalmente."
 
 *   **Path B: The tool returns `{"status": "success", ...}`**
     1.  This means a confident match was found. The compatible batteries are inside the `results` dictionary.


### PR DESCRIPTION
## Summary
- Ensure assistant escalates to human support when a follow-up battery search still yields `clarification_needed`
- Handle textual vehicle selections by matching user replies like "GT" to the appropriate option before re-running the search

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'utils')*


------
https://chatgpt.com/codex/tasks/task_e_68b8ba0e4e18832b9568c3b30bc658c9